### PR TITLE
replace int() w/ Int() and parse(Int, foo)

### DIFF
--- a/src/formatting_converting_strings.jl
+++ b/src/formatting_converting_strings.jl
@@ -1,9 +1,9 @@
-# strings can be converted using [float](http://julia.readthedocs.org/en/latest/stdlib/base/#Base.float) and [int](http://julia.readthedocs.org/en/latest/stdlib/base/#Base.int):
+# strings can be converted using [float](http://julia.readthedocs.org/en/latest/stdlib/base/#Base.float) and [parse](http://julia.readthedocs.org/en/latest/stdlib/numbers/#Base.parse):
 e_str1 = "2.718"
 e = float(e_str1)
 println(5e)
 #> 13.5914
-num_15 = int("15")
+num_15 = parse(Int, "15")
 println(3num_15)
 #> 45
 

--- a/src/strings_basics.jl
+++ b/src/strings_basics.jl
@@ -17,14 +17,14 @@ print(" that.\n")
 c1 = 'a'
 println(c1)
 #> a
-# the ascii value of a char can be found with int():
-println(c1, " ascii value = ", int(c1))
+# the ascii value of a char can be found with Int():
+println(c1, " ascii value = ", Int(c1))
 #> a ascii value = 97
-println("int('α') == ", int('α'))
-#> int('α') == 945
+println("Int('α') == ", Int('α'))
+#> Int('α') == 945
 
 # so be aware that
-println(int('1') == 1)
+println(Int('1') == 1)
 #> false
 
 # strings can be converted to upper case or lower case:


### PR DESCRIPTION
in Julia 0.4.3, `int()` has been deprecated in favor of `Int()` and `parse(Int,...)`


![dparfitt_ _julia_ _80x24](https://cloud.githubusercontent.com/assets/58244/13222253/2563e312-d94d-11e5-9f29-9f3d013137c2.png)
![dparfitt_ _julia_ _80x24](https://cloud.githubusercontent.com/assets/58244/13222261/2cbcff9a-d94d-11e5-8efe-eb65c234056f.png)

Cheers -
Dave
