### PR TITLE
Changed for loop to foreach to avoid syntax error in Julia 0.5 and later

### DIFF
--- a/src/string_manipulation.jl
+++ b/src/string_manipulation.jl
@@ -44,7 +44,7 @@ println(r)
 
 # [eachmatch](http://julia.readthedocs.org/en/latest/stdlib/base/#Base.eachmatch) returns an iterator over all the matches
 r = eachmatch(r"[\w]{4,}", s1)
-for(i in r) print("\"$(i.match)\" ") end
+foreach(i -> print("\"$(i.match)\" "), r)
 println()
 #> "quick" "brown" "jumps" "over" "lazy" 
 


### PR DESCRIPTION
Changed for loop to foreach. Previous parentheses syntax in for loop is not accepted 0.5 and onward, resulting in an error when trying to run this example. See https://github.com/JuliaLang/julia/issues/17668